### PR TITLE
Don't close on error

### DIFF
--- a/db.go
+++ b/db.go
@@ -570,6 +570,9 @@ func ReportAlreadyRead(db sq.BaseRunner, filename string) (bool, error) {
 		Where(sq.Eq{"filename": filename}).
 		Query()
 	defer func() {
+		if err != nil {
+			panic(err)
+		}
 		_ = rows.Close()
 	}()
 	if err != nil {


### PR DESCRIPTION
Took me far too long to figure out why I was getting seg faults when trying to import.
Eventually I hooked up a debugger and it was pretty obvious.

Before:
```
❯ ./build/jenkins-usage-stats import --database 'postgres://timja@localhost/jenkins_usage_stats?sslmode=disable&timezone=UTC' --directory build/reports
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x61 pc=0x102ceb878]

goroutine 1 [running]:
database/sql.(*Rows).closemuRUnlockIfHeldByScan(0x102f6d340?)
	/opt/homebrew/Cellar/go/1.23.4/libexec/src/database/sql/sql.go:3404 +0x18
database/sql.(*Rows).Close(0x0)
	/opt/homebrew/Cellar/go/1.23.4/libexec/src/database/sql/sql.go:3431 +0x20
github.com/jenkins-infra/jenkins-usage-stats.ReportAlreadyRead.func1()
	/Users/timja/code/jenkins/jenkins-usage-stats/db.go:573 +0x20
github.com/jenkins-infra/jenkins-usage-stats.ReportAlreadyRead({0x129fae158?, 0x140000a8300?}, {0x140000f0b20, 0x1e})
	/Users/timja/code/jenkins/jenkins-usage-stats/db.go:579 +0x26c
main.(*ImportOptions).runImport(0x140000923a0)
	/Users/timja/code/jenkins/jenkins-usage-stats/cmd/jenkins-usage-stats/import.go:90 +0x3f0
main.NewImportCmd.func1(0x140000f6300?, {0x102daf121?, 0x4?, 0x102daf125?})
	/Users/timja/code/jenkins/jenkins-usage-stats/cmd/jenkins-usage-stats/import.go:30 +0x20
github.com/spf13/cobra.(*Command).execute(0x14000134608, {0x140000be740, 0x4, 0x4})
	/Users/timja/code/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:989 +0x81c
github.com/spf13/cobra.(*Command).ExecuteC(0x14000134308)
	/Users/timja/code/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x344
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/timja/code/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041
main.run({0x102f707b0, 0x103297660})
	/Users/timja/code/jenkins/jenkins-usage-stats/cmd/jenkins-usage-stats/main.go:35 +0xd0
main.main()
	/Users/timja/code/jenkins/jenkins-usage-stats/cmd/jenkins-usage-stats/main.go:15 +0x2c
```

After:

```
panic: pq: relation "report_files" does not exist

goroutine 1 [running]:
github.com/jenkins-infra/jenkins-usage-stats.ReportAlreadyRead.func1()
	/Users/timja/code/jenkins/jenkins-usage-stats/db.go:574 +0x48
github.com/jenkins-infra/jenkins-usage-stats.ReportAlreadyRead({0x10158d318?, 0x1400000c300?}, {0x14000022be0, 0x1e})
	/Users/timja/code/jenkins/jenkins-usage-stats/db.go:582 +0x278
main.(*ImportOptions).runImport(0x1400013e380)
	/Users/timja/code/jenkins/jenkins-usage-stats/cmd/jenkins-usage-stats/import.go:90 +0x3f0
main.NewImportCmd.func1(0x14000150300?, {0x100e9f161?, 0x4?, 0x100e9f165?})
	/Users/timja/code/jenkins/jenkins-usage-stats/cmd/jenkins-usage-stats/import.go:30 +0x20
github.com/spf13/cobra.(*Command).execute(0x1400020a608, {0x1400003e780, 0x4, 0x4})
	/Users/timja/code/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:989 +0x81c
github.com/spf13/cobra.(*Command).ExecuteC(0x1400020a308)
	/Users/timja/code/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x344
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/timja/code/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041
main.run({0x1010607b0, 0x101383460})
	/Users/timja/code/jenkins/jenkins-usage-stats/cmd/jenkins-usage-stats/main.go:35 +0xd0
main.main()
	/Users/timja/code/jenkins/jenkins-usage-stats/cmd/jenkins-usage-stats/main.go:15 +0x2c
```

(Noticed as part of https://github.com/jenkins-infra/helpdesk/issues/4386)